### PR TITLE
Winter 20 release fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.vscode/*
+*.db
+*.ts
+force-app/main/default/lwc/.eslintrc.json
+force-app/main/default/lwc/jsconfig.json

--- a/.sfdx/sfdx-config.json
+++ b/.sfdx/sfdx-config.json
@@ -1,4 +1,4 @@
 {
     "defaultdevhubusername": "my-hub-org",
-    "defaultusername": "ADK"
+    "defaultusername": "gantt-chart2"
 }

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,7 +1,9 @@
 {
     "orgName": "spencerhsieh Company",
     "edition": "Developer",
-    "orgPreferences" : {
-        "enabled": ["S1DesktopEnabled"]
+    "settings": {
+        "lightningExperienceSettings": {
+            "enableS1DesktopEnabled": true
+        }
     }
 }

--- a/force-app/main/default/lwc/gantt_chart/gantt_chart.html
+++ b/force-app/main/default/lwc/gantt_chart/gantt_chart.html
@@ -91,7 +91,7 @@
               <div class="slds-grid">
                 <template for:each={dates} for:item="date">
                   <div
-                    key={date}
+                    key={date.name}
                     class="slds-col lwc-timeline_month-container"
                     style={date.style}
                   >
@@ -106,7 +106,7 @@
                     </div>
                     <div class="slds-grid">
                       <template for:each={date.days} for:item="day">
-                        <div key={day} class={day.class}>
+                        <div key={day.label} class={day.class}>
                           <div if:true={day.dayName}>{day.dayName}</div>
                           <div>{day.label}</div>
                         </div>

--- a/force-app/main/default/lwc/gantt_chart_resource/gantt_chart_resource.html
+++ b/force-app/main/default/lwc/gantt_chart_resource/gantt_chart_resource.html
@@ -23,7 +23,7 @@
             <!-- Time Slots-->
             <div class="slds-grid slds-is-absolute lwc-timeslots-container">
                 <template for:each={times} for:item="time" for:index="index">
-                    <div key={time} class={time.class} data-index={index} data-start={time.start} data-end={time.end}
+                    <div key={time.start} class={time.class} data-index={index} data-start={time.start} data-end={time.end}
                         onclick={handleTimeslotClick} ondragenter={handleDragEnter}>
                         <!-- nothing -->
                     </div>

--- a/force-app/main/default/lwc/gantt_chart_resource/gantt_chart_resource.js
+++ b/force-app/main/default/lwc/gantt_chart_resource/gantt_chart_resource.js
@@ -235,7 +235,7 @@ export default class GanttChartResource extends LightningElement {
         id: projectId,
         allocations: []
       };
-
+      /*
       self.resource.allocationsByProject[projectId].forEach(allocation => {
         allocation.class = self.calcClass(allocation);
         allocation.style = self.calcStyle(allocation);
@@ -243,6 +243,17 @@ export default class GanttChartResource extends LightningElement {
 
         project.allocations.push(allocation);
       });
+      */
+     //fix for Uncaught (in promise) TypeError: 'set' on proxy: trap returned falsish for property 'class'
+     self.resource.allocationsByProject[projectId].forEach(allocation2 => {
+        
+      let allocation = JSON.parse(JSON.stringify(allocation2))
+      allocation.class = self.calcClass(allocation);
+      allocation.style = self.calcStyle(allocation);
+      allocation.labelStyle = self.calcLabelStyle(allocation);
+
+      project.allocations.push(allocation);
+    });
 
       self.projects.push(project);
     });


### PR DESCRIPTION
Winter 20 release fixes.

1. for:each= keys have to be an integer or string: keys were pointing at an object
2. Set values on an object that was read-only: project.allocations
3 Fixed scratch org deploy issue:
    ERROR running force:org:create:  We've deprecated OrgPreferences. Update the scratch org definition 
    file to replace OrgPreferences with their corresponding settings.